### PR TITLE
fix Chinese&Japanese erroneous newline

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2159,22 +2159,38 @@ void RichTextLabel::add_text(const String &p_text) {
 		} else {
 			line = p_text.substr(pos, end - pos);
 		}
-
-		if (line.length() > 0) {
-			if (current->subitems.size() && current->subitems.back()->get()->type == ITEM_TEXT) {
-				//append text condition!
-				ItemText *ti = static_cast<ItemText *>(current->subitems.back()->get());
-				ti->text += line;
-				_invalidate_current_line(main);
-
-			} else {
-				//append item condition
+		
+		int lipos = 0;
+		while (lipos < line.length()) {
+			if (line[lipos] >= 0x3040 && line[lipos] < 0xfaff) {
+				//Chinese or Japanese word condition
 				ItemText *item = memnew(ItemText);
-				item->text = line;
+				item->text = line.substr(lipos, 1);
 				_add_item(item, false);
-			}
-		}
+				//append one by one
+				lipos++;
+			} else {
+				//English word condition
+				int o;//length of English words
+				for (o = 1; o < (line.length() - lipos) && (line[lipos + o] < 0x3040 || line[lipos + o] > 0xfaff); o++) {
+				}
+				if (current->subitems.size() && current->subitems.back()->get()->type == ITEM_TEXT) {
+					//append text condition!
+					ItemText *ti = static_cast<ItemText *>(current->subitems.back()->get());
+					ti->text += line.substr(lipos, o);
+					_invalidate_current_line(main);
 
+				} else {
+					//append item condition
+					ItemText *item = memnew(ItemText);
+					item->text = line.substr(lipos, o);
+					_add_item(item, false);
+				}
+				lipos += o;
+				}
+			}
+
+		
 		if (eol) {
 			ItemNewline *item = memnew(ItemNewline);
 			item->line = current_frame->lines.size();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
## Problem

Chinese&Japanese erroneous newline.For examples:
`parse_bbcode("向最坏处着想,向最好处努力")`
![image](https://user-images.githubusercontent.com/77611914/104926130-b9360580-59da-11eb-8b1c-be9f08d72286.png)
It's correct newline.But,when I add bbcode tag:
`parse_bbcode("向[b]最坏处着想,向最好处努力")`
![image](https://user-images.githubusercontent.com/77611914/104926716-788abc00-59db-11eb-924c-b8531dfb6d80.png)
It's wrong newline.Around at bbcode tag instead of correct place.
`parse_bbcode("向[b]最坏[/b]处着想,向最好处努力")`
![image](https://user-images.githubusercontent.com/77611914/104927757-c7852100-59dc-11eb-91f6-26b65ce4e57c.png)

## Reason

Chinese&Japanese do not use space or any character for separating words.
So,a Chinese&Japanese sentence will be considered as a word.
BBcode tag will separate words,rich text lable try to put a word in one line,
then,it will newline in erroneous place.

## Solve

For Chinese&Japanese,unicode greater than 0x3040 and less than 0xfaff,add them to the tag stack one by one.

![image](https://user-images.githubusercontent.com/77611914/104929259-9ad20900-59de-11eb-8785-7d1a614d04e0.png)

My code causes other language and punctuation "sticking" to previous Chinese&Japanese char.
——For punctuation,it conforms to the Chinese grammar standard.
——For other language,it can be solved by adding a space between other language and Chinese&Japanese.